### PR TITLE
Update requirements.txt, support osx metal

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 numpy==1.21.5
-taichi==1.4.0
+taichi==1.5.0


### PR DESCRIPTION
Taichi 1.4.0 GUI Windows didn't run on OSX Metal. Upgrading to 1.5.0 allows this demo to run on M1 Mac with Metal.